### PR TITLE
Cleaning up Direct3D Resources.

### DIFF
--- a/DriverRW/main.cpp
+++ b/DriverRW/main.cpp
@@ -39,7 +39,20 @@ void CleanupDeviceD3D()
         g_pd3dDevice->Release();
         g_pd3dDevice = nullptr;
     }
+    
+    // Release any other Direct3D resources here, e.g. textures, buffers, shaders
+
+    // Release the Direct3D debug interface if it exists
+    #ifdef _DEBUG
+        if (g_pd3dDebug)
+        {
+            g_pd3dDebug->ReportLiveDeviceObjects(D3D11_RLDO_SUMMARY | D3D11_RLDO_DETAIL);
+            g_pd3dDebug->Release();
+            g_pd3dDebug = nullptr;
+        }
+    #endif
 }
+
 
 NTSTATUS
 {


### PR DESCRIPTION
- Added comments to explain the purpose of each section of the code.
- Added a note to release any other Direct3D resources that may have been created during initialization and are still being used.
- Added a section to release the Direct3D debug interface, if it exists. This is only included in debug builds, as it can be helpful for debugging memory leaks and other issues.

Add logging or error handling: It's unclear what should happen if any of the cleanup operations fail. Adding some logging or error handling can help to ensure that the cleanup process completes successfully and can aid in debugging if something goes wrong.


Use smart pointers: Rather than manually releasing each object and interface, consider using smart pointers to manage their lifetimes. This can help to prevent memory leaks and make the code more readable.